### PR TITLE
fix(aurelia): adds preset.ts in to satisfy storybook

### DIFF
--- a/app/aurelia/src/server/options.ts
+++ b/app/aurelia/src/server/options.ts
@@ -4,5 +4,5 @@ import { LoadOptions } from '@storybook/core-common';
 export default {
   packageJson: sync({ cwd: __dirname }).packageJson,
   framework: 'aurelia',
-  frameworkPresets: [require.resolve('./framework-preset-aurelia.js')],
+  frameworkPresets: [require.resolve('./preset')],
 } as LoadOptions;

--- a/app/aurelia/src/server/preset.ts
+++ b/app/aurelia/src/server/preset.ts
@@ -1,0 +1,9 @@
+import type { StorybookConfig } from '@storybook/core-common';
+
+export const previewAnnotations: StorybookConfig['previewAnnotations'] = (entries = []) => [
+  ...entries,
+  // Not sure if we need this for Aurelia? I've otherwise copied the rest of this file from the angular stuff
+  // require.resolve('../client/preview/config'),
+];
+
+export const addons: StorybookConfig['addons'] = [require.resolve('./framework-preset-aurelia')];


### PR DESCRIPTION
In my project I was importing this into, I was getting failures because Storybook was looking for `preset.ts` which didn't exist. I've copied the angular preset.ts and cut it back to bare minimums but I'm not sure about the client preview stuff...